### PR TITLE
GEN-7662 update django version 2.1.5 to 2.2.9

### DIFF
--- a/pycon_kr_2017_addnull/_provisioning/requirements.txt
+++ b/pycon_kr_2017_addnull/_provisioning/requirements.txt
@@ -1,3 +1,3 @@
-Django==2.1.5
+Django==2.2.9
 djangorestframework==3.9.0
 factory-boy==2.11.1


### PR DESCRIPTION
### What is this PR for?
- github 보안이슈 Django 2.1.5 -> 2.2.9
### How should this be tested?
- test code를 실행해주세요